### PR TITLE
chore(*) fix rockspec source url

### DIFF
--- a/sandbox-1.0.1-1.rockspec
+++ b/sandbox-1.0.1-1.rockspec
@@ -1,9 +1,9 @@
 package = "sandbox"
 
-version = "1.0.1-0"
+version = "1.0.1-1"
 
 source = {
-   url = "git://github.com/kikito/sandbox.lua.git",
+   url = "https://github.com/kikito/sandbox.lua.git",
    tag = "v1.0.1"
 }
 


### PR DESCRIPTION
we cannot install this rock anymore due to a github security change:

```text
Installing https://luarocks.org/manifests/kikito/sandbox-1.0.1-0.rockspec
Cloning into 'sandbox.lua'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

Error: Failed cloning git repository.
```

Let me know if you prefer to do a patch release for this?