### PR TITLE
fix(rockspec) revert git protocol

### DIFF
--- a/sandbox-1.0.1-4.rockspec
+++ b/sandbox-1.0.1-4.rockspec
@@ -1,9 +1,9 @@
 package = "sandbox"
 
-version = "1.0.1-3"
+version = "1.0.1-4"
 
 source = {
-   url = "git+https://github.com/kikito/sandbox.lua",
+   url = "git://github.com/kikito/sandbox.lua.git",
    tag = "v1.0.1"
 }
 


### PR DESCRIPTION
this is affecting people that are working on older ee branches and also OSS users. this  is a quick revert to unblock everyone. Of course, this will break again at the next github security brownout.

https://github.com/Kong/kong/issues/8040