### PR TITLE
Test if quotas are supported by Lua(JIT) version

### DIFF
--- a/sandbox.lua
+++ b/sandbox.lua
@@ -29,9 +29,19 @@ local sandbox = {
 
 }
 
--- quotas don't work in LuaJIT since debug.sethook works differently there
-local quota_supported = type(_G.jit) == "nil"
-sandbox.quota_supported = quota_supported
+-- test if quotas are supported by current Lua(JIT) version
+sandbox.quota_supported = (function()
+  local quota_supported = false
+  local chunk = (load or loadstring)("local i = 0; while i < 1000 do i = i + 1 end")
+  debug.sethook(function()
+    debug.sethook()
+    quota_supported = true 
+  end, "", 100)
+  pcall(chunk)
+  debug.sethook()
+  return quota_supported
+end)()
+
 
 -- PUC-Rio Lua 5.1 does not support deactivation of bytecode
 local bytecode_blocked = _ENV or type(_G.jit) == "table"


### PR DESCRIPTION
There is an undocumented compile option LUAJIT_ENABLE_CHECKHOOK,
which only works under certain constraints. Please check the
description at the end of src/lj_record.c.

https://www.freelists.org/post/luajit/lua-sethook,1
https://github.com/LuaJIT/LuaJIT/blob/1cdff194cfa22cfe5bfc0e908b909e2dea40aa70/src/lj_record.c#L2802